### PR TITLE
fix docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:10.7-alpine
     volumes:
       - db-data:/var/lib/postgresql/data
-      - "db:/docker-entrypoint-initdb.d/postgres-init.sql"
+      - ".db/docker-entrypoint-initdb.d/postgres-init.sql"
     ports:
       - "5432:5432"
     networks:
@@ -38,7 +38,8 @@ services:
       - backend
     depends_on:
       - db
-    #environment:
+    environment:
+      DB_HOST_NAME: db
     restart: always
 
 networks:
@@ -47,4 +48,3 @@ networks:
       
 volumes:
   db-data:
-  db:


### PR DESCRIPTION
Hi @AlecApp ,
The 2 bugs were:

1.  An absolute path vs a relative path in regards to the path to the init script.  BTW, this mounting of init scripts into the init directory that some database vendors provide is a really great feature.  It allows us to create database objects in the database at runtime.
2.  This one was trickier.  Notice in the readme there is a portion that talks about the database connectivity configuration, a typescript file.  Looking at that file you'll notice that the application looks for an environment variable called DB_HOST_NAME.  If it cannot find that env var then it fails to 0.0.0.0.  That's why you were receiving that error.  So, what we do here is pass in that environment variable where DB_HOST_NAME is equal to the db service.  Docker then knows how to resolve that hostname.  Pretty slick.